### PR TITLE
Integrate Cube Challenge minigame into library

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,56 +1,71 @@
-.header-top {
-    display: flex;
-    width: 100%;
-    justify-content: center;
-    height: 125px;
-    align-items: center;
-
+* {
+    box-sizing: border-box;
 }
 
 body {
-    font-family: Arial, sans-serif;
-    text-align: center;
+    margin: 0;
+    font-family: 'Inter', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    color: #111827;
     background:
-            radial-gradient(circle at center, rgba(255, 255, 255, 0.8) 0%, rgba(240, 240, 240, 0.4) 50%, rgba(220, 220, 220, 0.2) 100%),
-            repeating-linear-gradient(
-                    45deg,
-                    rgba(255, 255, 255, 0.3) 0,
-                    rgba(255, 255, 255, 0.3) 1px,
-                    transparent 1px,
-                    transparent 40px
-            ),
-            repeating-linear-gradient(
-                    -45deg,
-                    rgba(255, 255, 255, 0.3) 0,
-                    rgba(255, 255, 255, 0.3) 1px,
-                    transparent 1px,
-                    transparent 40px
-            ),
-            linear-gradient(to bottom, #EEECE1 0%, #3E4333 100%);
-    background-repeat: repeat;
-    background-blend-mode: normal, normal, normal, lighten;
+            radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.95), rgba(230, 230, 230, 0.45)),
+            radial-gradient(circle at 80% 0%, rgba(240, 248, 255, 0.8), rgba(210, 220, 240, 0.25)),
+            linear-gradient(180deg, #f8f9fc 0%, #d6e0ff 100%);
+    min-height: 100vh;
 }
 
-
-h1 {
-    margin-bottom: 30px;
+#root {
+    min-height: 100vh;
 }
 
-.container {
+.app-header {
     display: flex;
-    justify-content: center;
-    gap: 20px;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.5rem 3vw 1rem;
+}
+
+.app-header__title {
+    font-size: clamp(1.8rem, 3vw, 2.4rem);
+    margin: 0;
+    letter-spacing: 0.04em;
+}
+
+.app-header__nav {
+    display: flex;
+    gap: 1rem;
     flex-wrap: wrap;
 }
 
-.box {
-    width: 150px;
-    height: 150px;
-    background-color: #e0e0e0;
-    border: 2px solid #ccc;
-    border-radius: 10px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-weight: bold;
+.app-header__link {
+    padding: 0.55rem 1.1rem;
+    border-radius: 999px;
+    text-decoration: none;
+    color: rgba(17, 24, 39, 0.7);
+    font-weight: 600;
+    background: rgba(255, 255, 255, 0.7);
+    box-shadow: 0 8px 18px rgba(15, 15, 15, 0.12);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+}
+
+.app-header__link:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 24px rgba(15, 15, 15, 0.18);
+    color: rgba(17, 24, 39, 0.85);
+}
+
+.app-header__link--active {
+    color: #0f62fe;
+    box-shadow: 0 10px 24px rgba(15, 98, 254, 0.2);
+}
+
+@media (max-width: 640px) {
+    .app-header {
+        justify-content: center;
+    }
+
+    .app-header__nav {
+        justify-content: center;
+    }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,18 @@
-import './App.css'
+import './App.css';
 import AngledCarousel from './components/AngledCarousel.tsx';
-import {Route, Routes} from 'react-router-dom';
-import Header from "./components/Header.tsx";
-import NotFound from "./components/NotFound.tsx";
-import {useEffect, useState} from "react";
-
+import { Route, Routes } from 'react-router-dom';
+import Header from './components/Header.tsx';
+import NotFound from './components/NotFound.tsx';
+import { useEffect, useState } from 'react';
+import ListOfGames from './components/ListOfGames.tsx';
+import CubeChallenge from './components/games/CubeChallenge.tsx';
 
 function App() {
-
-    const [tg, setTg] = useState(null);
+    const [, setTelegramWebApp] = useState<unknown | null>(null);
 
     useEffect(() => {
         if (window.Telegram && window.Telegram.WebApp) {
-            setTg(window.Telegram.WebApp);
+            setTelegramWebApp(window.Telegram.WebApp);
             window.Telegram.WebApp.ready();
         }
         const script = document.createElement('script');
@@ -21,7 +21,7 @@ function App() {
 
         script.onload = () => {
             if (window.Telegram && window.Telegram.WebApp) {
-                setTg(window.Telegram.WebApp);
+                setTelegramWebApp(window.Telegram.WebApp);
                 window.Telegram.WebApp.ready();
             }
         };
@@ -35,20 +35,16 @@ function App() {
 
     return (
         <>
-            <Header/>
+            <Header />
 
             <Routes>
-                <Route path="*" element={<NotFound/>}/>
-                <Route path="/" element={<AngledCarousel/>}/>
-
-
+                <Route path="/" element={<ListOfGames />} />
+                <Route path="/games/cube-challenge" element={<CubeChallenge />} />
+                <Route path="/carousel" element={<AngledCarousel />} />
+                <Route path="*" element={<NotFound />} />
             </Routes>
-
-
-            {/*// <Carousel />*/}
         </>
-    )
+    );
 }
 
-export default App
-
+export default App;

--- a/src/components/AngledCarousel.tsx
+++ b/src/components/AngledCarousel.tsx
@@ -1,211 +1,231 @@
-'use client'
+'use client';
 
-import { useRef, useState, useEffect, useCallback } from 'react'
-import { motion, AnimatePresence } from 'framer-motion'
+import { useRef, useState, useEffect, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
 
-import sigmavideoone from "../../public/video/v1.mp4"
-import skibidivideoone from "../../public/video/v2.mp4"
-import brrbrrvideoone from "../../public/video/v3.mp4"
-import tungtungtungtungtungtungtungvideo from "../../public/video/v4.mp4"
+import sigmavideoone from '../../public/video/v1.mp4';
+import skibidivideoone from '../../public/video/v2.mp4';
+import brrbrrvideoone from '../../public/video/v3.mp4';
+import tungtungtungtungtungtungtungvideo from '../../public/video/v4.mp4';
 
-// угол передаётся в градусах, но нужен в радианах
-const toRad = (deg) => (deg * Math.PI) / 180
+interface CarouselItem {
+    video: string;
+    title?: string;
+    text?: string;
+}
 
-const AngledCarousel = ({
-  items = [
+interface AngledCarouselProps {
+    items?: CarouselItem[];
+    angle?: number;
+    cardWidth?: number;
+    cardHeight?: number;
+    spacing?: number;
+    descriptionLimit?: number;
+    modalWidth?: number;
+    modalHeight?: number;
+    moreLabel?: string;
+    closeLabel?: string;
+}
+
+const DEFAULT_ITEMS: CarouselItem[] = [
     { video: sigmavideoone, title: 'Sigma Video', text: 'This is the first carousel video.' },
     {
-      video: skibidivideoone,
-      title: 'Skibidi Video',
-      text:
-        'Cube Challenge – Take your puzzle-solving skills to the next level with this advanced Rubik’s Cube game. Designed for seasoned cubers and daring beginners alike, it offers complex patterns, time challenges, and mind-bending twists that push your spatial reasoning and memory to the limit. Solve increasingly difficult scrambles, unlock new cube sizes and shapes, and test yourself against the clock—or challenge friends in head-to-head puzzle duels. With sleek animations, customizable cube designs, and an immersive 3D interface, this is more than just a cube… it’s a mental battleground.',
+        video: skibidivideoone,
+        title: 'Skibidi Video',
+        text: 'Cube Challenge – Take your puzzle-solving skills to the next level with this advanced Rubik’s Cube game. Designed for seasoned cubers and daring beginners alike, it offers complex patterns, time challenges, and mind-bending twists that push your spatial reasoning and memory to the limit. Solve increasingly difficult scrambles, unlock new cube sizes and shapes, and test yourself against the clock—or challenge friends in head-to-head puzzle duels. With sleek animations, customizable cube designs, and an immersive 3D interface, this is more than just a cube… it’s a mental battleground.',
     },
     { video: brrbrrvideoone, title: 'Brr Brr Video', text: 'This is the third carousel video.' },
     { video: tungtungtungtungtungtungtungvideo, title: 'Tung Tung Tung', text: 'This is the fourth carousel video.' },
-  ],
-  angle = 20,
-  cardWidth = 720, // безопасный дефолт без window.* (SSR friendly)
-  cardHeight = 520,
-  spacing = 1.1,
-  descriptionLimit = 200, // n — порог длины описания, после которого показываем кнопку "more"
-  modalWidth = 800,
-  modalHeight = 500,
-  moreLabel = 'more',
-  closeLabel = 'Close',
+];
+
+const toRad = (deg: number) => (deg * Math.PI) / 180;
+
+const AngledCarousel: React.FC<AngledCarouselProps> = ({
+    items = DEFAULT_ITEMS,
+    angle = 20,
+    cardWidth = 720,
+    cardHeight = 520,
+    spacing = 1.1,
+    descriptionLimit = 200,
+    modalWidth = 800,
+    modalHeight = 500,
+    moreLabel = 'more',
+    closeLabel = 'Close',
 }) => {
-  const [currentIndex, setCurrentIndex] = useState(Math.floor(items.length / 2))
-  const [openIdx, setOpenIdx] = useState(null) // индекс карточки, для которой открыт модал
-  const containerRef = useRef(null)
+    const [currentIndex, setCurrentIndex] = useState<number>(Math.floor(items.length / 2));
+    const [openIdx, setOpenIdx] = useState<number | null>(null);
+    const containerRef = useRef<HTMLDivElement | null>(null);
 
-  const rad = toRad(angle)
-  const step = cardWidth * spacing
+    const rad = toRad(angle);
+    const step = cardWidth * spacing;
 
-  const handleWheel = useCallback(
-    (e) => {
-      // блокируем дефолтный скролл, чтобы прокрутка управляла только каруселью
-      e.preventDefault()
-      const delta = Math.sign(e.deltaY)
-      setCurrentIndex((index) => {
-        const nextIndex = index + delta
-        return Math.max(0, Math.min(nextIndex, items.length - 1))
-      })
-    },
-    [items.length]
-  )
+    const handleWheel = useCallback(
+        (event: WheelEvent) => {
+            event.preventDefault();
+            const delta = Math.sign(event.deltaY);
+            setCurrentIndex((index) => {
+                const nextIndex = index + delta;
+                return Math.max(0, Math.min(nextIndex, items.length - 1));
+            });
+        },
+        [items.length],
+    );
 
-  // Закрытие модалки по ESC
-  useEffect(() => {
-    const onKey = (e) => {
-      if (e.key === 'Escape') setOpenIdx(null)
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [])
+    useEffect(() => {
+        const onKey = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                setOpenIdx(null);
+            }
+        };
 
-  useEffect(() => {
-    const container = containerRef.current
-    if (!container) return
-    container.addEventListener('wheel', handleWheel, { passive: false })
-    return () => container.removeEventListener('wheel', handleWheel)
-  }, [handleWheel])
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, []);
 
-  const truncate = (s, n) => (s.length > n ? s.slice(0, Math.max(0, n)).trimEnd() + '…' : s)
+    useEffect(() => {
+        const container = containerRef.current;
+        if (!container) return;
 
-  return (
-    <div
-      ref={containerRef}
-      className="relative w-full overflow-hidden select-none flex justify-center items-center"
-      style={{ height: cardHeight * 2 }}
-    >
-      {items.map((item, idx) => {
-        const offset = idx - currentIndex
-        const isActive = offset === 0
-        const xPos = offset * step * Math.cos(rad)
-        const yPos = offset * step * Math.sin(rad)
-        const scale = isActive ? 1 : 0.85
-        const opacity = isActive ? 1 : 0.5
-        const zIndex = 100 - Math.abs(offset)
+        container.addEventListener('wheel', handleWheel, { passive: false });
+        return () => {
+            container.removeEventListener('wheel', handleWheel);
+        };
+    }, [handleWheel]);
 
-        const isLong = (item.text || '').length > descriptionLimit
+    const truncate = useCallback(
+        (text: string, limit: number) => (text.length > limit ? `${text.slice(0, Math.max(0, limit)).trimEnd()}…` : text),
+        [],
+    );
 
-        return (
-          <motion.div
-            key={idx}
-            animate={{ x: xPos, y: yPos, scale, opacity, zIndex }}
-            transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-            className="absolute rounded-lg cursor-pointer flex"
-            onClick={() => setCurrentIndex(idx)}
-            style={{ width: cardWidth + 250, height: cardHeight }} // место справа под текст
-          >
-            {/* Видео */}
-            <video
-              src={item.video}
-              width={cardWidth - 125}
-              height={cardHeight - 16}
-              autoPlay
-              loop
-              muted
-              playsInline
-              className="flex-shrink-0 rounded-l-lg"
-            />
+    return (
+        <div
+            ref={containerRef}
+            className="relative w-full overflow-hidden select-none flex justify-center items-center"
+            style={{ height: cardHeight * 2 }}
+        >
+            {items.map((item, idx) => {
+                const offset = idx - currentIndex;
+                const isActive = offset === 0;
+                const xPos = offset * step * Math.cos(rad);
+                const yPos = offset * step * Math.sin(rad);
+                const scale = isActive ? 1 : 0.85;
+                const opacity = isActive ? 1 : 0.5;
+                const zIndex = 100 - Math.abs(offset);
 
-            {/* Правая колонка */}
-            <div className="w-full p-3 pr-4 flex flex-col justify-center gap-3 rounded-r-lg">
-              {/* Верхний бокс (заголовок) */}
-              <motion.div
-                initial={{ opacity: 0, y: -10 }}
-                animate={isActive ? { opacity: 1, y: 0 } : { opacity: 0, y: -10 }}
-                transition={{ duration: 0.4 }}
-                className="bg-white/90 backdrop-blur rounded-xl shadow-md px-4 py-3"
-              >
-                <h2 className="text-lg font-semibold tracking-wide">{item.title ?? 'Untitled'}</h2>
-              </motion.div>
+                const description = item.text ?? '';
+                const isLong = description.length > descriptionLimit;
 
-              {/* Нижний бокс (описание) */}
-              <motion.div
-                initial={{ opacity: 0, y: 10 }}
-                animate={isActive ? { opacity: 1, y: 0 } : { opacity: 0, y: 10 }}
-                transition={{ duration: 0.4, delay: 0.1 }}
-                className="bg-gray-50/90 backdrop-blur rounded-xl shadow-inner px-4 py-4"
-              >
-                <p className="text-gray-800 text-sm leading-relaxed">
-                  {isLong ? truncate(item.text, descriptionLimit) : item.text}
-                </p>
-
-                {isLong && (
-                  <div className="mt-3">
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        setOpenIdx(idx)
-                      }}
-                      className="text-sm font-medium underline underline-offset-4 hover:opacity-80 focus:outline-none"
-                    >
-                      {moreLabel}
-                    </button>
-                  </div>
-                )}
-              </motion.div>
-
-              {/* Модальное окно для полного описания */}
-              <AnimatePresence>
-                {openIdx === idx && (
-                  <motion.div
-                    key="modal"
-                    className="fixed inset-0 z-[999] flex items-center justify-center"
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    exit={{ opacity: 0 }}
-                  >
-                    {/* Бекдроп */}
+                return (
                     <motion.div
-                      className="absolute inset-0 bg-black/50 backdrop-blur-sm"
-                      aria-hidden="true"
-                      onClick={() => setOpenIdx(null)}
-                      initial={{ opacity: 0 }}
-                      animate={{ opacity: 1 }}
-                      exit={{ opacity: 0 }}
-                    />
-
-                    {/* Диалог */}
-                    <motion.div
-                      role="dialog"
-                      aria-modal="true"
-                      aria-label={item.title ?? 'Details'}
-                      initial={{ opacity: 0, scale: 0.95, y: 16 }}
-                      animate={{ opacity: 1, scale: 1, y: 0 }}
-                      exit={{ opacity: 0, scale: 0.98, y: 8 }}
-                      transition={{ type: 'spring', stiffness: 260, damping: 24 }}
-                      className="relative bg-white rounded-2xl shadow-2xl p-6 mx-4"
-                      style={{ width: modalWidth, height: modalHeight }}
-                      onClick={(e) => e.stopPropagation()}
+                        key={idx}
+                        animate={{ x: xPos, y: yPos, scale, opacity, zIndex }}
+                        transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+                        className="absolute rounded-lg cursor-pointer flex"
+                        onClick={() => setCurrentIndex(idx)}
+                        style={{ width: cardWidth + 250, height: cardHeight }}
                     >
-                      <button
-                        type="button"
-                        aria-label="Close"
-                        className="absolute top-3 right-3 rounded-xl px-3 py-1 text-sm hover:bg-gray-100 focus:outline-none"
-                        onClick={() => setOpenIdx(null)}
-                      >
-                        {closeLabel}
-                      </button>
+                        <video
+                            src={item.video}
+                            width={cardWidth - 125}
+                            height={cardHeight - 16}
+                            autoPlay
+                            loop
+                            muted
+                            playsInline
+                            className="flex-shrink-0 rounded-l-lg"
+                        />
 
-                      <h3 className="text-xl font-semibold mb-3 pr-16">{item.title ?? 'Details'}</h3>
-                      <div className="h-[calc(100%-4.5rem)] overflow-auto pr-1">
-                        <p className="text-gray-800 text-base leading-relaxed whitespace-pre-wrap">
-                          {item.text}
-                        </p>
-                      </div>
+                        <div className="w-full p-3 pr-4 flex flex-col justify-center gap-3 rounded-r-lg">
+                            <motion.div
+                                initial={{ opacity: 0, y: -10 }}
+                                animate={isActive ? { opacity: 1, y: 0 } : { opacity: 0, y: -10 }}
+                                transition={{ duration: 0.4 }}
+                                className="bg-white/90 backdrop-blur rounded-xl shadow-md px-4 py-3"
+                            >
+                                <h2 className="text-lg font-semibold tracking-wide">{item.title ?? 'Untitled'}</h2>
+                            </motion.div>
+
+                            <motion.div
+                                initial={{ opacity: 0, y: 10 }}
+                                animate={isActive ? { opacity: 1, y: 0 } : { opacity: 0, y: 10 }}
+                                transition={{ duration: 0.4, delay: 0.1 }}
+                                className="bg-gray-50/90 backdrop-blur rounded-xl shadow-inner px-4 py-4"
+                            >
+                                <p className="text-gray-800 text-sm leading-relaxed">
+                                    {isLong ? truncate(description, descriptionLimit) : description}
+                                </p>
+
+                                {isLong && (
+                                    <div className="mt-3">
+                                        <button
+                                            type="button"
+                                            onClick={(event) => {
+                                                event.stopPropagation();
+                                                setOpenIdx(idx);
+                                            }}
+                                            className="text-sm font-medium underline underline-offset-4 hover:opacity-80 focus:outline-none"
+                                        >
+                                            {moreLabel}
+                                        </button>
+                                    </div>
+                                )}
+                            </motion.div>
+
+                            <AnimatePresence>
+                                {openIdx === idx && (
+                                    <motion.div
+                                        key="modal"
+                                        className="fixed inset-0 z-[999] flex items-center justify-center"
+                                        initial={{ opacity: 0 }}
+                                        animate={{ opacity: 1 }}
+                                        exit={{ opacity: 0 }}
+                                    >
+                                        <motion.div
+                                            className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+                                            aria-hidden="true"
+                                            onClick={() => setOpenIdx(null)}
+                                            initial={{ opacity: 0 }}
+                                            animate={{ opacity: 1 }}
+                                            exit={{ opacity: 0 }}
+                                        />
+
+                                        <motion.div
+                                            role="dialog"
+                                            aria-modal="true"
+                                            aria-label={item.title ?? 'Details'}
+                                            initial={{ opacity: 0, scale: 0.95, y: 16 }}
+                                            animate={{ opacity: 1, scale: 1, y: 0 }}
+                                            exit={{ opacity: 0, scale: 0.98, y: 8 }}
+                                            transition={{ type: 'spring', stiffness: 260, damping: 24 }}
+                                            className="relative bg-white rounded-2xl shadow-2xl p-6 mx-4"
+                                            style={{ width: modalWidth, height: modalHeight }}
+                                            onClick={(event) => event.stopPropagation()}
+                                        >
+                                            <button
+                                                type="button"
+                                                aria-label="Close"
+                                                className="absolute top-3 right-3 rounded-xl px-3 py-1 text-sm hover:bg-gray-100 focus:outline-none"
+                                                onClick={() => setOpenIdx(null)}
+                                            >
+                                                {closeLabel}
+                                            </button>
+
+                                            <h3 className="text-xl font-semibold mb-3 pr-16">{item.title ?? 'Details'}</h3>
+                                            <div className="h-[calc(100%-4.5rem)] overflow-auto pr-1">
+                                                <p className="text-gray-800 text-base leading-relaxed whitespace-pre-wrap">
+                                                    {description}
+                                                </p>
+                                            </div>
+                                        </motion.div>
+                                    </motion.div>
+                                )}
+                            </AnimatePresence>
+                        </div>
                     </motion.div>
-                  </motion.div>
-                )}
-              </AnimatePresence>
-            </div>
-          </motion.div>
-        )
-      })}
-    </div>
-  )
-}
+                );
+            })}
+        </div>
+    );
+};
 
-export default AngledCarousel
+export default AngledCarousel;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,12 +1,28 @@
+import { NavLink } from 'react-router-dom';
+
 const Header = () => {
     return (
-        <>
-            <h1 className={"header-top"}>List Of Games</h1>
+        <header className="app-header">
+            <h1 className="app-header__title">Mini Games Hub</h1>
+            <nav className="app-header__nav" aria-label="Primary navigation">
+                <NavLink to="/" end className={({ isActive }) => `app-header__link ${isActive ? 'app-header__link--active' : ''}`}>
+                    Library
+                </NavLink>
+                <NavLink
+                    to="/games/cube-challenge"
+                    className={({ isActive }) => `app-header__link ${isActive ? 'app-header__link--active' : ''}`}
+                >
+                    Cube Challenge
+                </NavLink>
+                <NavLink
+                    to="/carousel"
+                    className={({ isActive }) => `app-header__link ${isActive ? 'app-header__link--active' : ''}`}
+                >
+                    Featured
+                </NavLink>
+            </nav>
+        </header>
+    );
+};
 
-
-        </>
-
-
-    )
-}
-export default Header
+export default Header;

--- a/src/components/ListOfGames.css
+++ b/src/components/ListOfGames.css
@@ -1,0 +1,156 @@
+.game-library {
+    display: grid;
+    grid-template-columns: minmax(240px, 320px) minmax(0, 1fr);
+    gap: 2rem;
+    padding: 1.5rem 3vw 3rem;
+    align-items: start;
+}
+
+.game-library__sidebar {
+    background: rgba(255, 255, 255, 0.75);
+    border-radius: 18px;
+    padding: 1.5rem;
+    box-shadow: 0 14px 30px rgba(20, 20, 20, 0.18);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.game-library__heading {
+    margin: 0;
+    font-size: clamp(1.4rem, 2.5vw, 1.75rem);
+}
+
+.game-library__intro {
+    margin: 0;
+    font-size: 0.95rem;
+    color: rgba(0, 0, 0, 0.7);
+}
+
+.game-library__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.game-library__list-item {
+    margin: 0;
+}
+
+.game-library__item {
+    width: 100%;
+    padding: 0.85rem 1rem;
+    background: rgba(248, 248, 248, 0.9);
+    border: 2px solid transparent;
+    border-radius: 14px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.35rem;
+    cursor: pointer;
+    transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: 0 10px 18px rgba(15, 15, 15, 0.15);
+}
+
+.game-library__item:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 14px 24px rgba(15, 15, 15, 0.18);
+}
+
+.game-library__item--active {
+    border-color: #0f62fe;
+    box-shadow: 0 16px 30px rgba(15, 98, 254, 0.25);
+}
+
+.game-library__item-name {
+    font-size: 1rem;
+    font-weight: 700;
+}
+
+.game-library__item-genre {
+    font-size: 0.85rem;
+    color: rgba(0, 0, 0, 0.6);
+}
+
+.game-library__badge {
+    margin-top: 0.25rem;
+    font-size: 0.75rem;
+    background: rgba(15, 15, 15, 0.08);
+    border-radius: 999px;
+    padding: 0.15rem 0.6rem;
+    text-transform: uppercase;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+}
+
+.game-library__content {
+    background: rgba(255, 255, 255, 0.78);
+    border-radius: 24px;
+    padding: 1.75rem;
+    box-shadow: 0 18px 36px rgba(22, 24, 32, 0.18);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.game-library__details {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.game-library__details-title {
+    font-size: clamp(1.5rem, 2.5vw, 2rem);
+    margin: 0;
+}
+
+.game-library__details-description {
+    margin: 0;
+    font-size: 1rem;
+    color: rgba(0, 0, 0, 0.7);
+}
+
+.game-library__demo {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.game-placeholder {
+    padding: 2.5rem 2rem;
+    border-radius: 18px;
+    background: linear-gradient(135deg, rgba(15, 98, 254, 0.12), rgba(66, 190, 101, 0.12));
+    color: rgba(17, 24, 39, 0.75);
+    text-align: center;
+    font-size: 1rem;
+    max-width: 420px;
+}
+
+@media (max-width: 900px) {
+    .game-library {
+        grid-template-columns: 1fr;
+    }
+
+    .game-library__sidebar {
+        order: 2;
+    }
+
+    .game-library__content {
+        order: 1;
+    }
+}
+
+@media (max-width: 540px) {
+    .game-library {
+        padding: 1.25rem 5vw 2.5rem;
+        gap: 1.5rem;
+    }
+
+    .game-library__sidebar,
+    .game-library__content {
+        padding: 1.25rem;
+    }
+}

--- a/src/components/ListOfGames.tsx
+++ b/src/components/ListOfGames.tsx
@@ -1,29 +1,104 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
+import CubeChallenge from './games/CubeChallenge';
+import './ListOfGames.css';
 
-interface Game {
-    id: number;
+interface GameDefinition {
+    id: string;
     name: string;
     genre: string;
+    description: string;
+    playable: boolean;
+    component: React.ComponentType;
 }
 
-const games: Game[] = [
-    {id: 1, name: 'The Legend of Zelda: Breath of the Wild', genre: 'Adventure'},
-    {id: 2, name: 'Elden Ring', genre: 'Action RPG'},
-    {id: 3, name: 'Minecraft', genre: 'Sandbox'},
+const PlaceholderGame: React.FC<{ title: string }> = ({ title }) => (
+    <div className="game-placeholder">
+        <p>
+            <strong>{title}</strong> is coming soon. Stay tuned for its official release!
+        </p>
+    </div>
+);
+
+const createPlaceholderGame = (title: string): React.ComponentType => () => <PlaceholderGame title={title} />;
+
+const games: GameDefinition[] = [
+    {
+        id: 'cube-challenge',
+        name: 'Cube Challenge',
+        genre: '3D Puzzle',
+        description: 'Tumble a colourful 3D cube, practise finger tricks with the keyboard or shake things up with a scramble.',
+        playable: true,
+        component: CubeChallenge,
+    },
+    {
+        id: 'zelda',
+        name: 'The Legend of Zelda: Breath of the Wild',
+        genre: 'Adventure',
+        description: 'Explore Hyrule with Link in a sprawling open world filled with shrines, Koroks and epic boss battles.',
+        playable: false,
+        component: createPlaceholderGame('The Legend of Zelda: Breath of the Wild'),
+    },
+    {
+        id: 'elden-ring',
+        name: 'Elden Ring',
+        genre: 'Action RPG',
+        description: 'Face the Lands Between, collect Great Runes and forge your path to become the Elden Lord.',
+        playable: false,
+        component: createPlaceholderGame('Elden Ring'),
+    },
+    {
+        id: 'minecraft',
+        name: 'Minecraft',
+        genre: 'Sandbox',
+        description: 'Gather resources, build without limits and survive the night in this creative sandbox phenomenon.',
+        playable: false,
+        component: createPlaceholderGame('Minecraft'),
+    },
 ];
 
-const GameList: React.FC = () => {
+const ListOfGames: React.FC = () => {
+    const [selectedGameId, setSelectedGameId] = useState<string>(games[0].id);
+
+    const selectedGame = useMemo(() => games.find((game) => game.id === selectedGameId) ?? games[0], [selectedGameId]);
+    const SelectedGameComponent = selectedGame.component;
+
     return (
-        <div>
-            <ul className={"container"}>
-                {games.map((game) => (
-                    <li key={game.id} className={"box"}>
-                        <strong>{game.name}</strong> - {game.genre}
-                    </li>
-                ))}
-            </ul>
+        <div className="game-library">
+            <aside className="game-library__sidebar">
+                <h2 className="game-library__heading">Game Library</h2>
+                <p className="game-library__intro">Select a game to learn more or play a quick demo.</p>
+                <ul className="game-library__list">
+                    {games.map((game) => {
+                        const isActive = game.id === selectedGameId;
+                        return (
+                            <li key={game.id} className="game-library__list-item">
+                                <button
+                                    type="button"
+                                    onClick={() => setSelectedGameId(game.id)}
+                                    className={`game-library__item ${isActive ? 'game-library__item--active' : ''}`}
+                                    aria-pressed={isActive}
+                                >
+                                    <span className="game-library__item-name">{game.name}</span>
+                                    <span className="game-library__item-genre">{game.genre}</span>
+                                    {!game.playable && <span className="game-library__badge">Preview</span>}
+                                </button>
+                            </li>
+                        );
+                    })}
+                </ul>
+            </aside>
+
+            <section className="game-library__content" aria-live="polite">
+                <div className="game-library__details">
+                    <h3 className="game-library__details-title">{selectedGame.name}</h3>
+                    <p className="game-library__details-description">{selectedGame.description}</p>
+                </div>
+                <div className="game-library__demo">
+                    <SelectedGameComponent />
+                </div>
+            </section>
         </div>
     );
 };
 
-export default GameList;
+export default ListOfGames;

--- a/src/components/games/CubeChallenge.css
+++ b/src/components/games/CubeChallenge.css
@@ -1,0 +1,161 @@
+.cube-game {
+    --cube-size: clamp(220px, 55vw, 340px);
+    --sticker-gap: 6px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+    color: #0b0b0b;
+}
+
+.cube-game__header {
+    text-align: center;
+    max-width: 640px;
+}
+
+.cube-game__title {
+    font-size: clamp(1.5rem, 2.5vw, 2rem);
+    margin-bottom: 0.35rem;
+}
+
+.cube-game__subtitle {
+    font-size: 0.95rem;
+    color: rgba(30, 30, 30, 0.75);
+    margin: 0 auto;
+}
+
+.cube-game__stage {
+    width: min(90vw, 420px);
+    aspect-ratio: 1 / 1;
+    border-radius: 24px;
+    background: radial-gradient(circle at 50% 20%, rgba(255, 255, 255, 0.95), rgba(210, 210, 210, 0.6));
+    box-shadow: 0 18px 40px rgba(13, 16, 23, 0.25);
+    outline: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: grab;
+    position: relative;
+}
+
+.cube-game__stage:active {
+    cursor: grabbing;
+}
+
+.cube-game__scene {
+    width: 100%;
+    height: 100%;
+    perspective: 900px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.cube-game__cube {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: var(--cube-size);
+    height: var(--cube-size);
+    transform-style: preserve-3d;
+    transition: transform 0.12s ease-out;
+}
+
+.cube-game__face {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(3, 1fr);
+    gap: var(--sticker-gap);
+    padding: var(--sticker-gap);
+    box-sizing: border-box;
+    background: #020202;
+    border-radius: 18px;
+    box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.35);
+}
+
+.cube-game__face--front { transform: translateZ(calc(var(--cube-size) / 2)); }
+.cube-game__face--back { transform: rotateY(180deg) translateZ(calc(var(--cube-size) / 2)); }
+.cube-game__face--left { transform: rotateY(-90deg) translateZ(calc(var(--cube-size) / 2)); }
+.cube-game__face--right { transform: rotateY(90deg) translateZ(calc(var(--cube-size) / 2)); }
+.cube-game__face--top { transform: rotateX(90deg) translateZ(calc(var(--cube-size) / 2)); }
+.cube-game__face--bottom { transform: rotateX(-90deg) translateZ(calc(var(--cube-size) / 2)); }
+
+.cube-game__sticker {
+    border-radius: 8px;
+    box-shadow:
+        inset 0 0 4px rgba(0, 0, 0, 0.35),
+        0 4px 6px rgba(11, 11, 11, 0.35);
+}
+
+.cube-game__footer {
+    width: 100%;
+    max-width: 640px;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.cube-game__buttons {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+}
+
+.cube-game__button {
+    border: none;
+    border-radius: 999px;
+    padding: 0.6rem 1.5rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    background: rgba(255, 255, 255, 0.8);
+    color: #1b1b1b;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: 0 10px 20px rgba(30, 30, 30, 0.15);
+}
+
+.cube-game__button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 14px 24px rgba(30, 30, 30, 0.2);
+}
+
+.cube-game__button:active {
+    transform: translateY(0);
+    box-shadow: 0 8px 16px rgba(30, 30, 30, 0.18);
+}
+
+.cube-game__button--primary {
+    background: linear-gradient(135deg, #0f62fe, #42be65);
+    color: #ffffff;
+}
+
+.cube-game__help {
+    font-size: 0.85rem;
+    color: rgba(33, 33, 33, 0.7);
+}
+
+.cube-game__help kbd {
+    background: rgba(0, 0, 0, 0.08);
+    border-radius: 4px;
+    padding: 0.1rem 0.3rem;
+    font-size: 0.85em;
+    margin: 0 0.1rem;
+    display: inline-block;
+}
+
+@media (max-width: 600px) {
+    .cube-game {
+        gap: 1.25rem;
+    }
+
+    .cube-game__buttons {
+        flex-direction: column;
+    }
+
+    .cube-game__button {
+        width: 100%;
+    }
+}

--- a/src/components/games/CubeChallenge.tsx
+++ b/src/components/games/CubeChallenge.tsx
@@ -1,0 +1,157 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import './CubeChallenge.css';
+
+type Rotation = {
+    x: number;
+    y: number;
+};
+
+const ROTATION_STEP = 15;
+const DRAG_SENSITIVITY = 0.4;
+
+const scrambleRotation = (): Rotation => {
+    const randomAngle = () => Math.round((Math.random() * 360 - 180) / ROTATION_STEP) * ROTATION_STEP;
+    return {
+        x: randomAngle(),
+        y: randomAngle(),
+    };
+};
+
+const CubeChallenge: React.FC = () => {
+    const [rotation, setRotation] = useState<Rotation>(() => ({ x: -30, y: 35 }));
+    const dragOrigin = useRef<{ x: number; y: number } | null>(null);
+
+    const handlePointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+        dragOrigin.current = { x: event.clientX, y: event.clientY };
+        event.currentTarget.setPointerCapture(event.pointerId);
+    }, []);
+
+    const handlePointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+        if (!dragOrigin.current) {
+            return;
+        }
+
+        const deltaX = event.clientX - dragOrigin.current.x;
+        const deltaY = event.clientY - dragOrigin.current.y;
+        dragOrigin.current = { x: event.clientX, y: event.clientY };
+
+        setRotation((prev) => ({
+            x: prev.x + deltaY * DRAG_SENSITIVITY,
+            y: prev.y + deltaX * DRAG_SENSITIVITY,
+        }));
+    }, []);
+
+    const handlePointerUp = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+        dragOrigin.current = null;
+        event.currentTarget.releasePointerCapture(event.pointerId);
+    }, []);
+
+    const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+        const key = event.key;
+        if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(key)) {
+            return;
+        }
+
+        event.preventDefault();
+
+        setRotation((prev) => {
+            switch (key) {
+                case 'ArrowUp':
+                    return { x: prev.x - ROTATION_STEP, y: prev.y };
+                case 'ArrowDown':
+                    return { x: prev.x + ROTATION_STEP, y: prev.y };
+                case 'ArrowLeft':
+                    return { x: prev.x, y: prev.y - ROTATION_STEP };
+                case 'ArrowRight':
+                    return { x: prev.x, y: prev.y + ROTATION_STEP };
+                case 'Home':
+                    return { x: -30, y: 35 };
+                case 'End':
+                    return scrambleRotation();
+                default:
+                    return prev;
+            }
+        });
+    }, []);
+
+    const rotationStyle = useMemo(
+        () => ({
+            transform: `translate3d(-50%, -50%, 0) rotateX(${rotation.x}deg) rotateY(${rotation.y}deg)`,
+        }),
+        [rotation.x, rotation.y],
+    );
+
+    const scramble = useCallback(() => {
+        setRotation(scrambleRotation());
+    }, []);
+
+    const reset = useCallback(() => {
+        setRotation({ x: -30, y: 35 });
+    }, []);
+
+    return (
+        <section className="cube-game">
+            <header className="cube-game__header">
+                <h3 className="cube-game__title">Cube Challenge</h3>
+                <p className="cube-game__subtitle">Rotate the cube by dragging, or use your keyboard for precise moves.</p>
+            </header>
+
+            <div
+                className="cube-game__stage"
+                role="application"
+                aria-label="Interactive 3D cube"
+                tabIndex={0}
+                onPointerDown={handlePointerDown}
+                onPointerMove={handlePointerMove}
+                onPointerUp={handlePointerUp}
+                onPointerCancel={handlePointerUp}
+                onKeyDown={handleKeyDown}
+            >
+                <div className="cube-game__scene">
+                    <div className="cube-game__cube" style={rotationStyle}>
+                        <CubeFace className="cube-game__face cube-game__face--front" color="#0f62fe" label="Front" />
+                        <CubeFace className="cube-game__face cube-game__face--back" color="#ff7eb6" label="Back" />
+                        <CubeFace className="cube-game__face cube-game__face--left" color="#42be65" label="Left" />
+                        <CubeFace className="cube-game__face cube-game__face--right" color="#fa4d56" label="Right" />
+                        <CubeFace className="cube-game__face cube-game__face--top" color="#f1c21b" label="Top" />
+                        <CubeFace className="cube-game__face cube-game__face--bottom" color="#a56eff" label="Bottom" />
+                    </div>
+                </div>
+            </div>
+
+            <footer className="cube-game__footer">
+                <div className="cube-game__buttons">
+                    <button type="button" className="cube-game__button" onClick={reset}>
+                        Reset
+                    </button>
+                    <button type="button" className="cube-game__button cube-game__button--primary" onClick={scramble}>
+                        Scramble
+                    </button>
+                </div>
+                <p className="cube-game__help">
+                    Keyboard shortcuts: use arrow keys to rotate, <kbd>Home</kbd> to reset and <kbd>End</kbd> to scramble.
+                </p>
+            </footer>
+        </section>
+    );
+};
+
+interface CubeFaceProps {
+    className: string;
+    color: string;
+    label: string;
+}
+
+const CubeFace: React.FC<CubeFaceProps> = ({ className, color, label }) => {
+    const stickers = useMemo(() => Array.from({ length: 9 }), []);
+
+    return (
+        <div className={className} data-label={label}>
+            {stickers.map((_, index) => (
+                <span key={index} className="cube-game__sticker" style={{ backgroundColor: color }} />
+            ))}
+        </div>
+    );
+};
+
+export default CubeChallenge;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,15 @@
 /// <reference types="vite/client" />
+
+declare global {
+    interface TelegramWebApp {
+        ready: () => void;
+    }
+
+    interface Window {
+        Telegram?: {
+            WebApp?: TelegramWebApp;
+        };
+    }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- add a Cube Challenge game component with keyboard and pointer controls plus dedicated styling
- refactor the game library to display the new cube game alongside curated placeholders with improved layout
- refresh the app shell by wiring routes, header navigation, typed carousel props, and Telegram WebApp definitions

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cea880b8c88326a492f122b4f4d9cc