### PR TITLE
Replace cube move buttons with draggable controls

### DIFF
--- a/src/components/games/CubeChallenge.css
+++ b/src/components/games/CubeChallenge.css
@@ -108,7 +108,7 @@
 
 .cube-game__move-groups {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
     gap: 0.9rem;
 }
 
@@ -119,7 +119,9 @@
     box-shadow: 0 12px 24px rgba(15, 18, 25, 0.08);
     display: flex;
     flex-direction: column;
-    gap: 0.6rem;
+    align-items: stretch;
+    gap: 0.75rem;
+    text-align: center;
 }
 
 .cube-game__move-title {
@@ -130,35 +132,158 @@
     text-transform: uppercase;
 }
 
-.cube-game__move-buttons {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 0.45rem;
+.cube-game__move-control {
+    --move-track-background: linear-gradient(145deg, rgba(255, 255, 255, 0.97), rgba(230, 230, 230, 0.92));
+    --move-track-highlight: transparent;
+    --move-track-highlight-opacity: 0;
+    --move-handle-background: linear-gradient(135deg, #ffffff, #f4f4f4);
+    --move-handle-text: #0b0b0b;
+    --move-handle-outline: rgba(15, 98, 254, 0.18);
+    --move-handle-shadow: 0 10px 20px rgba(14, 16, 24, 0.16);
+    --move-handle-shadow-active: 0 16px 28px rgba(14, 16, 24, 0.22);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.55rem;
 }
 
-.cube-game__move-button {
-    border: none;
-    border-radius: 10px;
-    padding: 0.5rem 0.35rem;
+.cube-game__move-control--dragging {
+    --move-handle-shadow: var(--move-handle-shadow-active);
+}
+
+.cube-game__move-control--cw {
+    --move-track-highlight: linear-gradient(90deg, rgba(66, 190, 101, 0.35), rgba(66, 190, 101, 0));
+    --move-track-highlight-opacity: 1;
+    --move-handle-background: linear-gradient(135deg, #42be65, #1e9a53);
+    --move-handle-text: #ffffff;
+    --move-handle-outline: rgba(66, 190, 101, 0.45);
+}
+
+.cube-game__move-control--ccw {
+    --move-track-highlight: linear-gradient(270deg, rgba(15, 98, 254, 0.32), rgba(15, 98, 254, 0));
+    --move-track-highlight-opacity: 1;
+    --move-handle-background: linear-gradient(135deg, #0f62fe, #0b4ed9);
+    --move-handle-text: #ffffff;
+    --move-handle-outline: rgba(15, 98, 254, 0.45);
+}
+
+.cube-game__move-control--double {
+    --move-track-highlight: linear-gradient(180deg, rgba(161, 109, 255, 0.38), rgba(161, 109, 255, 0));
+    --move-track-highlight-opacity: 1;
+    --move-handle-background: linear-gradient(135deg, #a16dff, #7b4fe5);
+    --move-handle-text: #ffffff;
+    --move-handle-outline: rgba(161, 109, 255, 0.45);
+}
+
+.cube-game__move-track {
+    position: relative;
+    width: 100%;
+    min-height: 112px;
+    padding: 1.1rem;
+    border-radius: 18px;
+    background: var(--move-track-background);
+    box-shadow: 0 14px 28px rgba(15, 18, 25, 0.14);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    touch-action: none;
+    cursor: grab;
+}
+
+.cube-game__move-control--dragging .cube-game__move-track {
+    cursor: grabbing;
+}
+
+.cube-game__move-track::before {
+    content: '';
+    position: absolute;
+    inset: 14px;
+    border-radius: 14px;
+    border: 1px solid rgba(12, 16, 24, 0.12);
+    background:
+        linear-gradient(90deg, rgba(15, 18, 25, 0.08), rgba(15, 18, 25, 0.08)) center/1px 100% no-repeat,
+        linear-gradient(0deg, rgba(15, 18, 25, 0.08), rgba(15, 18, 25, 0.08)) center/100% 1px no-repeat;
+    pointer-events: none;
+}
+
+.cube-game__move-track::after {
+    content: '';
+    position: absolute;
+    inset: 14px;
+    border-radius: 14px;
+    background: var(--move-track-highlight);
+    opacity: var(--move-track-highlight-opacity);
+    transition: opacity 0.18s ease;
+    pointer-events: none;
+}
+
+.cube-game__move-label {
+    position: absolute;
+    font-size: 0.75rem;
     font-weight: 600;
-    font-size: 0.95rem;
-    background: linear-gradient(135deg, rgba(15, 98, 254, 0.08), rgba(66, 190, 101, 0.08));
-    color: #0b0b0b;
-    cursor: pointer;
-    box-shadow: 0 6px 14px rgba(13, 13, 13, 0.12);
-    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+    letter-spacing: 0.04em;
+    color: rgba(20, 20, 20, 0.62);
+    text-transform: uppercase;
+    pointer-events: none;
 }
 
-.cube-game__move-button:hover {
-    transform: translateY(-2px);
-    background: linear-gradient(135deg, rgba(15, 98, 254, 0.18), rgba(66, 190, 101, 0.18));
-    box-shadow: 0 12px 20px rgba(15, 18, 25, 0.16);
+.cube-game__move-label--left {
+    left: 18px;
+    top: 50%;
+    transform: translateY(-50%);
+    text-align: left;
 }
 
-.cube-game__move-button:active {
-    transform: translateY(0);
-    box-shadow: 0 6px 14px rgba(15, 18, 25, 0.18);
+.cube-game__move-label--right {
+    right: 18px;
+    top: 50%;
+    transform: translateY(-50%);
+    text-align: right;
+}
 
+.cube-game__move-label--top {
+    top: 18px;
+    left: 50%;
+    transform: translateX(-50%);
+}
+
+.cube-game__move-handle {
+    position: relative;
+    width: 56px;
+    height: 56px;
+    border-radius: 999px;
+    background: var(--move-handle-background);
+    color: var(--move-handle-text);
+    font-weight: 700;
+    font-size: 0.76rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    display: grid;
+    place-items: center;
+    box-shadow: var(--move-handle-shadow);
+    border: 2px solid var(--move-handle-outline);
+    transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+    pointer-events: none;
+    user-select: none;
+}
+
+.cube-game__move-intent {
+    font-size: 0.8rem;
+    color: rgba(30, 30, 30, 0.72);
+    min-height: 1.2em;
+}
+
+.cube-game__move-control--cw .cube-game__move-intent {
+    color: #1f9a54;
+}
+
+.cube-game__move-control--ccw .cube-game__move-intent {
+    color: #0f62fe;
+}
+
+.cube-game__move-control--double .cube-game__move-intent {
+    color: #8458e6;
 }
 
 .cube-game__buttons {
@@ -216,16 +341,29 @@
         gap: 1.25rem;
     }
 
-
     .cube-game__move-groups {
-        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
         gap: 0.7rem;
     }
 
-    .cube-game__move-button {
-        font-size: 0.9rem;
+    .cube-game__move-track {
+        min-height: 100px;
+        padding: 0.9rem;
     }
 
+    .cube-game__move-label {
+        font-size: 0.68rem;
+    }
+
+    .cube-game__move-handle {
+        width: 52px;
+        height: 52px;
+        font-size: 0.7rem;
+    }
+
+    .cube-game__move-intent {
+        font-size: 0.76rem;
+    }
 
     .cube-game__buttons {
         flex-direction: column;

--- a/src/components/games/CubeChallenge.tsx
+++ b/src/components/games/CubeChallenge.tsx
@@ -8,6 +8,15 @@ type FaceKey = 'U' | 'D' | 'F' | 'B' | 'R' | 'L';
 type BaseMove = FaceKey;
 type Move = `${BaseMove}${'' | "'" | '2'}`;
 
+type DragIntent = 'cw' | 'ccw' | 'double' | null;
+
+interface PointerDragState {
+    pointerId: number;
+    originX: number;
+    originY: number;
+    activeMove: Move | null;
+}
+
 interface Rotation {
     x: number;
     y: number;
@@ -25,6 +34,8 @@ interface CubeSticker {
 const ROTATION_STEP = 15;
 const DRAG_SENSITIVITY = 0.4;
 const SCRAMBLE_LENGTH = 25;
+const MOVE_DRAG_THRESHOLD = 28;
+const HANDLE_VISUAL_LIMIT = 36;
 
 const FACE_COLORS: Record<FaceKey, string> = {
     U: '#ffffff',
@@ -124,7 +135,7 @@ const MOVE_SPECS: Record<BaseMove, MoveSpec> = {
     L: { axis: 'x', layer: -1, clockwiseDirection: 1 },
 };
 
-const MOVE_GROUPS: Array<{ face: BaseMove; moves: Move[] }> = [
+const MOVE_GROUPS: Array<{ face: BaseMove; moves: [Move, Move, Move] }> = [
     { face: 'U', moves: ['U', "U'", 'U2'] },
     { face: 'D', moves: ['D', "D'", 'D2'] },
     { face: 'F', moves: ['F', "F'", 'F2'] },
@@ -290,6 +301,193 @@ const CubeFace: React.FC<CubeFaceProps> = ({ className, colors, label }) => (
     </div>
 );
 
+interface DraggableMoveControlProps {
+    face: BaseMove;
+    moves: [Move, Move, Move];
+    onMove: (move: Move) => void;
+}
+
+const DraggableMoveControl: React.FC<DraggableMoveControlProps> = ({ face, moves, onMove }) => {
+    const [clockwise, counterClockwise, doubleTurn] = moves;
+    const [clockwiseLabel, counterClockwiseLabel, doubleLabel] = useMemo(
+        () => moves.map((move) => formatMoveLabel(move)),
+        [moves],
+    );
+    const descriptionId = useMemo(() => `cube-move-${face.toLowerCase()}-intent`, [face]);
+    const ariaLabel = useMemo(
+        () =>
+            `Drag to twist the ${face} face. Drag right for ${clockwiseLabel}, left for ${counterClockwiseLabel}, and vertically for ${doubleLabel}.`,
+        [clockwiseLabel, counterClockwiseLabel, doubleLabel, face],
+    );
+
+    const trackRef = useRef<HTMLDivElement | null>(null);
+    const pointerState = useRef<PointerDragState | null>(null);
+    const [intent, setIntent] = useState<DragIntent>(null);
+    const [dragOffset, setDragOffset] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+    const [isDragging, setIsDragging] = useState(false);
+
+    const clampOffset = useCallback((value: number) => {
+        if (value > HANDLE_VISUAL_LIMIT) {
+            return HANDLE_VISUAL_LIMIT;
+        }
+        if (value < -HANDLE_VISUAL_LIMIT) {
+            return -HANDLE_VISUAL_LIMIT;
+        }
+        return value;
+    }, []);
+
+    const finishDrag = useCallback(
+        (pointerId: number, commit: boolean) => {
+            const state = pointerState.current;
+            if (!state || state.pointerId !== pointerId) {
+                return;
+            }
+
+            if (commit && state.activeMove) {
+                onMove(state.activeMove);
+            }
+
+            pointerState.current = null;
+            setIntent(null);
+            setDragOffset({ x: 0, y: 0 });
+            setIsDragging(false);
+
+            if (trackRef.current?.hasPointerCapture(pointerId)) {
+                trackRef.current.releasePointerCapture(pointerId);
+            }
+        },
+        [onMove],
+    );
+
+    const handlePointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        pointerState.current = {
+            pointerId: event.pointerId,
+            originX: event.clientX,
+            originY: event.clientY,
+            activeMove: null,
+        };
+        setIsDragging(true);
+        setIntent(null);
+        setDragOffset({ x: 0, y: 0 });
+        trackRef.current?.setPointerCapture(event.pointerId);
+    }, []);
+
+    const handlePointerMove = useCallback(
+        (event: React.PointerEvent<HTMLDivElement>) => {
+            const state = pointerState.current;
+            if (!state || state.pointerId !== event.pointerId) {
+                return;
+            }
+
+            const deltaX = event.clientX - state.originX;
+            const deltaY = event.clientY - state.originY;
+
+            const nextOffset = {
+                x: clampOffset(deltaX),
+                y: clampOffset(deltaY),
+            };
+            setDragOffset((prev) =>
+                prev.x === nextOffset.x && prev.y === nextOffset.y ? prev : nextOffset,
+            );
+
+            const absX = Math.abs(deltaX);
+            const absY = Math.abs(deltaY);
+            let nextIntent: DragIntent = null;
+
+            if (absX >= MOVE_DRAG_THRESHOLD || absY >= MOVE_DRAG_THRESHOLD) {
+                if (absX > absY) {
+                    nextIntent = deltaX > 0 ? 'cw' : 'ccw';
+                } else {
+                    nextIntent = 'double';
+                }
+            }
+
+            setIntent((prev) => (prev === nextIntent ? prev : nextIntent));
+
+            if (nextIntent === 'cw') {
+                state.activeMove = clockwise;
+            } else if (nextIntent === 'ccw') {
+                state.activeMove = counterClockwise;
+            } else if (nextIntent === 'double') {
+                state.activeMove = doubleTurn;
+            } else {
+                state.activeMove = null;
+            }
+        },
+        [clampOffset, clockwise, counterClockwise, doubleTurn],
+    );
+
+    const handlePointerUp = useCallback(
+        (event: React.PointerEvent<HTMLDivElement>) => {
+            finishDrag(event.pointerId, true);
+        },
+        [finishDrag],
+    );
+
+    const handlePointerCancel = useCallback(
+        (event: React.PointerEvent<HTMLDivElement>) => {
+            finishDrag(event.pointerId, false);
+        },
+        [finishDrag],
+    );
+
+    const intentDescription = useMemo(() => {
+        switch (intent) {
+            case 'cw':
+                return `${face} clockwise (${clockwiseLabel})`;
+            case 'ccw':
+                return `${face} counter-clockwise (${counterClockwiseLabel})`;
+            case 'double':
+                return `${face} double turn (${doubleLabel})`;
+            default:
+                return `Drag horizontally for ${clockwiseLabel}/${counterClockwiseLabel} or vertically for ${doubleLabel}.`;
+        }
+    }, [clockwiseLabel, counterClockwiseLabel, doubleLabel, face, intent]);
+
+    const handleText = intent
+        ? intent === 'cw'
+            ? clockwiseLabel
+            : intent === 'ccw'
+              ? counterClockwiseLabel
+              : doubleLabel
+        : 'Drag';
+
+    const controlClassName = [
+        'cube-game__move-control',
+        isDragging ? 'cube-game__move-control--dragging' : null,
+        intent ? `cube-game__move-control--${intent}` : null,
+    ]
+        .filter((value): value is string => Boolean(value))
+        .join(' ');
+
+    return (
+        <div className={controlClassName}>
+            <div
+                ref={trackRef}
+                className="cube-game__move-track"
+                tabIndex={0}
+                aria-label={ariaLabel}
+                aria-describedby={descriptionId}
+                onPointerDown={handlePointerDown}
+                onPointerMove={handlePointerMove}
+                onPointerUp={handlePointerUp}
+                onPointerCancel={handlePointerCancel}
+            >
+                <span className="cube-game__move-label cube-game__move-label--left">{counterClockwiseLabel}</span>
+                <span className="cube-game__move-label cube-game__move-label--right">{clockwiseLabel}</span>
+                <span className="cube-game__move-label cube-game__move-label--top">{doubleLabel}</span>
+                <div className="cube-game__move-handle" style={{ transform: `translate(${dragOffset.x}px, ${dragOffset.y}px)` }}>
+                    {handleText}
+                </div>
+            </div>
+            <p id={descriptionId} className="cube-game__move-intent" aria-live="polite">
+                {intentDescription}
+            </p>
+        </div>
+    );
+};
+
 const CubeChallenge: React.FC = () => {
     const [rotation, setRotation] = useState<Rotation>(() => ({ x: -30, y: 35 }));
     const [cubeState, setCubeState] = useState<CubeSticker[]>(() => createInitialCubeState());
@@ -387,8 +585,7 @@ const CubeChallenge: React.FC = () => {
                 <h3 className="cube-game__title">Cube Challenge</h3>
 
                 <p className="cube-game__subtitle">
-                    Solve a full 3×3 cube with authentic face turns. Drag to inspect and use the notation buttons to manipulate each
-                    layer.
+                    Solve a full 3×3 cube with authentic face turns. Drag to inspect and drag the move pads to twist each layer.
                 </p>
 
             </header>
@@ -424,19 +621,7 @@ const CubeChallenge: React.FC = () => {
                         {MOVE_GROUPS.map((group) => (
                             <div key={group.face} className="cube-game__move-group">
                                 <span className="cube-game__move-title">{group.face} face</span>
-                                <div className="cube-game__move-buttons">
-                                    {group.moves.map((move) => (
-                                        <button
-                                            key={move}
-                                            type="button"
-                                            className="cube-game__move-button"
-                                            onClick={() => handleMove(move)}
-                                            aria-label={`Apply ${move} move`}
-                                        >
-                                            {formatMoveLabel(move)}
-                                        </button>
-                                    ))}
-                                </div>
+                                <DraggableMoveControl face={group.face} moves={group.moves} onMove={handleMove} />
                             </div>
                         ))}
                     </div>
@@ -451,8 +636,8 @@ const CubeChallenge: React.FC = () => {
                     </div>
                 </div>
                 <p className="cube-game__help">
-                    Use the notation buttons to rotate faces (U = Up, D = Down, etc.). Drag or use the arrow keys to inspect the cube.
-                    <kbd>Home</kbd> resets the view and <kbd>End</kbd> randomizes it.
+                    Drag each move pad horizontally for clockwise/counter-clockwise turns or vertically for a double turn. Drag or use
+                    the arrow keys to inspect the cube. <kbd>Home</kbd> resets the view and <kbd>End</kbd> randomizes it.
                 </p>
             </footer>
         </section>


### PR DESCRIPTION
## Summary
- replace the Cube Challenge button grid with a draggable move control that tracks pointer gestures and fires a single turn per drag
- restyle the move control area with track, handle, and intent highlighting to reflect clockwise, counter-clockwise, or double turns
- refresh the in-game instructions so they describe dragging the move pads instead of pressing notation buttons

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68ceb697f9d48326ba6793bfbb0b7f3c