### PR TITLE
Enable direct cube manipulation in Cube Challenge

### DIFF
--- a/src/components/games/CubeChallenge.css
+++ b/src/components/games/CubeChallenge.css
@@ -4,24 +4,28 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 1.5rem;
+    gap: 1.75rem;
     color: #0b0b0b;
 }
 
 .cube-game__header {
     text-align: center;
     max-width: 640px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
 }
 
 .cube-game__title {
     font-size: clamp(1.5rem, 2.5vw, 2rem);
-    margin-bottom: 0.35rem;
+    margin: 0;
 }
 
 .cube-game__subtitle {
     font-size: 0.95rem;
     color: rgba(30, 30, 30, 0.75);
     margin: 0 auto;
+    line-height: 1.6;
 }
 
 .cube-game__stage {
@@ -36,10 +40,60 @@
     justify-content: center;
     cursor: grab;
     position: relative;
+    overflow: hidden;
 }
 
 .cube-game__stage:active {
     cursor: grabbing;
+}
+
+.cube-game__stage-actions {
+    position: absolute;
+    top: 16px;
+    left: 16px;
+    display: flex;
+    gap: 0.5rem;
+    z-index: 2;
+}
+
+.cube-game__stage-button {
+    border: none;
+    border-radius: 999px;
+    padding: 0.4rem 0.95rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    background: rgba(255, 255, 255, 0.85);
+    color: #0b0b0b;
+    box-shadow: 0 12px 24px rgba(15, 18, 25, 0.16);
+    transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+    cursor: pointer;
+}
+
+.cube-game__stage-button:hover {
+    transform: translateY(-1px);
+    background: rgba(255, 255, 255, 0.95);
+    box-shadow: 0 16px 30px rgba(15, 18, 25, 0.2);
+}
+
+.cube-game__stage-button:active {
+    transform: translateY(0);
+    box-shadow: 0 10px 20px rgba(15, 18, 25, 0.14);
+}
+
+.cube-game__stage-button:focus-visible {
+    outline: 2px solid rgba(15, 98, 254, 0.6);
+    outline-offset: 2px;
+}
+
+.cube-game__stage-button--primary {
+    background: linear-gradient(135deg, #0f62fe, #335bff);
+    color: #ffffff;
+    box-shadow: 0 14px 28px rgba(15, 98, 254, 0.28);
+}
+
+.cube-game__stage-button--primary:hover {
+    background: linear-gradient(135deg, #3470ff, #5179ff);
 }
 
 .cube-game__scene {
@@ -49,6 +103,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    position: relative;
 }
 
 .cube-game__cube {
@@ -73,6 +128,62 @@
     background: #020202;
     border-radius: 18px;
     box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.35);
+    touch-action: none;
+}
+
+.cube-game__face--interactive {
+    cursor: grab;
+    transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.cube-game__face--dragging {
+    cursor: grabbing;
+}
+
+.cube-game__face::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 18px;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.2s ease, background 0.2s ease;
+}
+
+.cube-game__face--dragging::after {
+    opacity: 1;
+    background: rgba(15, 98, 254, 0.08);
+}
+
+.cube-game__face--intent-cw::after {
+    opacity: 1;
+    background: linear-gradient(135deg, rgba(66, 190, 101, 0.28), rgba(66, 190, 101, 0));
+}
+
+.cube-game__face--intent-ccw::after {
+    opacity: 1;
+    background: linear-gradient(225deg, rgba(15, 98, 254, 0.26), rgba(15, 98, 254, 0));
+}
+
+.cube-game__face--intent-double::after {
+    opacity: 1;
+    background: linear-gradient(180deg, rgba(161, 109, 255, 0.32), rgba(161, 109, 255, 0));
+}
+
+.cube-game__face--dragging .cube-game__sticker {
+    transform: translateZ(2px);
+}
+
+.cube-game__face--intent-cw .cube-game__sticker {
+    box-shadow: inset 0 0 6px rgba(33, 111, 63, 0.5), 0 6px 12px rgba(66, 190, 101, 0.25);
+}
+
+.cube-game__face--intent-ccw .cube-game__sticker {
+    box-shadow: inset 0 0 6px rgba(11, 55, 140, 0.55), 0 6px 12px rgba(15, 98, 254, 0.28);
+}
+
+.cube-game__face--intent-double .cube-game__sticker {
+    box-shadow: inset 0 0 6px rgba(92, 57, 165, 0.55), 0 6px 12px rgba(161, 109, 255, 0.28);
 }
 
 .cube-game__face--front { transform: translateZ(calc(var(--cube-size) / 2)); }
@@ -87,151 +198,20 @@
     box-shadow:
         inset 0 0 4px rgba(0, 0, 0, 0.35),
         0 4px 6px rgba(11, 11, 11, 0.35);
-}
-
-.cube-game__footer {
-    width: 100%;
-    max-width: 640px;
-    text-align: center;
-    display: flex;
-    flex-direction: column;
-
-    gap: 1rem;
-}
-
-.cube-game__controls {
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-    width: 100%;
-}
-
-.cube-game__move-groups {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: 0.9rem;
-}
-
-.cube-game__move-group {
-    background: rgba(255, 255, 255, 0.82);
-    border-radius: 16px;
-    padding: 0.85rem;
-    box-shadow: 0 12px 24px rgba(15, 18, 25, 0.08);
-    display: flex;
-    flex-direction: column;
-    gap: 0.6rem;
-}
-
-.cube-game__move-title {
-    font-size: 0.85rem;
-    font-weight: 600;
-    letter-spacing: 0.02em;
-    color: rgba(20, 20, 20, 0.65);
-    text-transform: uppercase;
-}
-
-.cube-game__move-buttons {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 0.45rem;
-}
-
-.cube-game__move-button {
-    border: none;
-    border-radius: 10px;
-    padding: 0.5rem 0.35rem;
-    font-weight: 600;
-    font-size: 0.95rem;
-    background: linear-gradient(135deg, rgba(15, 98, 254, 0.08), rgba(66, 190, 101, 0.08));
-    color: #0b0b0b;
-    cursor: pointer;
-    box-shadow: 0 6px 14px rgba(13, 13, 13, 0.12);
-    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-}
-
-.cube-game__move-button:hover {
-    transform: translateY(-2px);
-    background: linear-gradient(135deg, rgba(15, 98, 254, 0.18), rgba(66, 190, 101, 0.18));
-    box-shadow: 0 12px 20px rgba(15, 18, 25, 0.16);
-}
-
-.cube-game__move-button:active {
-    transform: translateY(0);
-    box-shadow: 0 6px 14px rgba(15, 18, 25, 0.18);
-
-}
-
-.cube-game__buttons {
-    display: flex;
-    justify-content: center;
-    gap: 0.75rem;
-    flex-wrap: wrap;
-
-}
-
-.cube-game__button {
-    border: none;
-    border-radius: 999px;
-    padding: 0.6rem 1.5rem;
-    font-size: 0.95rem;
-    font-weight: 600;
-    background: rgba(255, 255, 255, 0.8);
-    color: #1b1b1b;
-    cursor: pointer;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
-    box-shadow: 0 10px 20px rgba(30, 30, 30, 0.15);
 }
 
-.cube-game__button:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 14px 24px rgba(30, 30, 30, 0.2);
-}
-
-.cube-game__button:active {
-    transform: translateY(0);
-    box-shadow: 0 8px 16px rgba(30, 30, 30, 0.18);
-}
-
-.cube-game__button--primary {
-    background: linear-gradient(135deg, #0f62fe, #42be65);
-    color: #ffffff;
-}
-
-.cube-game__help {
-    font-size: 0.85rem;
-    color: rgba(33, 33, 33, 0.7);
-}
-
-.cube-game__help kbd {
-    background: rgba(0, 0, 0, 0.08);
-    border-radius: 4px;
-    padding: 0.1rem 0.3rem;
-    font-size: 0.85em;
-    margin: 0 0.1rem;
-    display: inline-block;
-}
-
-@media (max-width: 600px) {
+@media (max-width: 520px) {
     .cube-game {
-        gap: 1.25rem;
+        gap: 1.4rem;
     }
 
-
-    .cube-game__move-groups {
-        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-        gap: 0.7rem;
+    .cube-game__stage-actions {
+        top: 12px;
+        left: 12px;
     }
 
-    .cube-game__move-button {
-        font-size: 0.9rem;
-    }
-
-
-    .cube-game__buttons {
-        flex-direction: column;
-    }
-
-    .cube-game__button {
-        width: 100%;
+    .cube-game__stage-button {
+        padding: 0.35rem 0.8rem;
     }
 }

--- a/src/components/games/CubeChallenge.tsx
+++ b/src/components/games/CubeChallenge.tsx
@@ -1,12 +1,20 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import './CubeChallenge.css';
 
-
 type Coordinate = -1 | 0 | 1;
 type Axis = 'x' | 'y' | 'z';
 type FaceKey = 'U' | 'D' | 'F' | 'B' | 'R' | 'L';
 type BaseMove = FaceKey;
 type Move = `${BaseMove}${'' | "'" | '2'}`;
+
+type DragIntent = 'cw' | 'ccw' | 'double' | null;
+
+interface PointerDragState {
+    pointerId: number;
+    originX: number;
+    originY: number;
+    activeMove: Move | null;
+}
 
 interface Rotation {
     x: number;
@@ -25,6 +33,7 @@ interface CubeSticker {
 const ROTATION_STEP = 15;
 const DRAG_SENSITIVITY = 0.4;
 const SCRAMBLE_LENGTH = 25;
+const MOVE_DRAG_THRESHOLD = 28;
 
 const FACE_COLORS: Record<FaceKey, string> = {
     U: '#ffffff',
@@ -124,13 +133,22 @@ const MOVE_SPECS: Record<BaseMove, MoveSpec> = {
     L: { axis: 'x', layer: -1, clockwiseDirection: 1 },
 };
 
-const MOVE_GROUPS: Array<{ face: BaseMove; moves: Move[] }> = [
-    { face: 'U', moves: ['U', "U'", 'U2'] },
-    { face: 'D', moves: ['D', "D'", 'D2'] },
-    { face: 'F', moves: ['F', "F'", 'F2'] },
-    { face: 'B', moves: ['B', "B'", 'B2'] },
-    { face: 'R', moves: ['R', "R'", 'R2'] },
-    { face: 'L', moves: ['L', "L'", 'L2'] },
+const FACE_MOVES: Record<FaceKey, [Move, Move, Move]> = {
+    U: ['U', "U'", 'U2'],
+    D: ['D', "D'", 'D2'],
+    F: ['F', "F'", 'F2'],
+    B: ['B', "B'", 'B2'],
+    R: ['R', "R'", 'R2'],
+    L: ['L', "L'", 'L2'],
+};
+
+const FACE_RENDER_CONFIG = [
+    { face: 'F' as FaceKey, className: 'cube-game__face cube-game__face--front', label: 'Front' },
+    { face: 'B' as FaceKey, className: 'cube-game__face cube-game__face--back', label: 'Back' },
+    { face: 'L' as FaceKey, className: 'cube-game__face cube-game__face--left', label: 'Left' },
+    { face: 'R' as FaceKey, className: 'cube-game__face cube-game__face--right', label: 'Right' },
+    { face: 'U' as FaceKey, className: 'cube-game__face cube-game__face--top', label: 'Top' },
+    { face: 'D' as FaceKey, className: 'cube-game__face cube-game__face--bottom', label: 'Bottom' },
 ];
 
 const normalizeCoordinate = (value: number): Coordinate => {
@@ -269,21 +287,47 @@ const getFaceStickers = (stickers: CubeSticker[], face: FaceKey): string[] => {
     return colors;
 };
 
-const formatMoveLabel = (move: Move): string => move.replace("'", '′');
-
 const scrambleRotation = (): Rotation => ({
     x: Math.random() * 180 - 90,
     y: Math.random() * 360 - 180,
 });
 
 interface CubeFaceProps {
+    face: FaceKey;
     className: string;
     colors: string[];
     label: string;
+    onPointerDown: (face: FaceKey, event: React.PointerEvent<HTMLDivElement>) => void;
+    onPointerMove: (face: FaceKey, event: React.PointerEvent<HTMLDivElement>) => void;
+    onPointerUp: (face: FaceKey, event: React.PointerEvent<HTMLDivElement>) => void;
+    onPointerCancel: (face: FaceKey, event: React.PointerEvent<HTMLDivElement>) => void;
+    onKeyDown: (face: FaceKey, event: React.KeyboardEvent<HTMLDivElement>) => void;
 }
 
-const CubeFace: React.FC<CubeFaceProps> = ({ className, colors, label }) => (
-    <div className={className} data-label={label}>
+const CubeFace: React.FC<CubeFaceProps> = ({
+    face,
+    className,
+    colors,
+    label,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onPointerCancel,
+    onKeyDown,
+}) => (
+    <div
+        className={className}
+        data-label={label}
+        data-face={face}
+        role="button"
+        tabIndex={0}
+        aria-label={`${label} face`}
+        onPointerDown={(event) => onPointerDown(face, event)}
+        onPointerMove={(event) => onPointerMove(face, event)}
+        onPointerUp={(event) => onPointerUp(face, event)}
+        onPointerCancel={(event) => onPointerCancel(face, event)}
+        onKeyDown={(event) => onKeyDown(face, event)}
+    >
         {colors.map((color, index) => (
             <span key={index} className="cube-game__sticker" style={{ backgroundColor: color }} />
         ))}
@@ -293,21 +337,27 @@ const CubeFace: React.FC<CubeFaceProps> = ({ className, colors, label }) => (
 const CubeChallenge: React.FC = () => {
     const [rotation, setRotation] = useState<Rotation>(() => ({ x: -30, y: 35 }));
     const [cubeState, setCubeState] = useState<CubeSticker[]>(() => createInitialCubeState());
-    const dragOrigin = useRef<{ x: number; y: number } | null>(null);
+    const stageDragOrigin = useRef<{ x: number; y: number } | null>(null);
+    const faceDragState = useRef<(PointerDragState & { face: FaceKey }) | null>(null);
+    const [activeFaceDrag, setActiveFaceDrag] = useState<{ face: FaceKey; intent: DragIntent } | null>(null);
 
-    const handlePointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
-        dragOrigin.current = { x: event.clientX, y: event.clientY };
-        event.currentTarget.setPointerCapture(event.pointerId);
-    }, []);
-
-    const handlePointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
-        if (!dragOrigin.current) {
+    const handleStagePointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+        if ((event.target as HTMLElement).closest('[data-face]')) {
             return;
         }
 
-        const deltaX = event.clientX - dragOrigin.current.x;
-        const deltaY = event.clientY - dragOrigin.current.y;
-        dragOrigin.current = { x: event.clientX, y: event.clientY };
+        stageDragOrigin.current = { x: event.clientX, y: event.clientY };
+        event.currentTarget.setPointerCapture(event.pointerId);
+    }, []);
+
+    const handleStagePointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+        if (!stageDragOrigin.current) {
+            return;
+        }
+
+        const deltaX = event.clientX - stageDragOrigin.current.x;
+        const deltaY = event.clientY - stageDragOrigin.current.y;
+        stageDragOrigin.current = { x: event.clientX, y: event.clientY };
 
         setRotation((prev) => ({
             x: prev.x + deltaY * DRAG_SENSITIVITY,
@@ -315,9 +365,11 @@ const CubeChallenge: React.FC = () => {
         }));
     }, []);
 
-    const handlePointerUp = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
-        dragOrigin.current = null;
-        event.currentTarget.releasePointerCapture(event.pointerId);
+    const handleStagePointerUp = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+        stageDragOrigin.current = null;
+        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+            event.currentTarget.releasePointerCapture(event.pointerId);
+        }
     }, []);
 
     const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -357,12 +409,12 @@ const CubeChallenge: React.FC = () => {
 
     const faceColors = useMemo(
         () => ({
-            front: getFaceStickers(cubeState, 'F'),
-            back: getFaceStickers(cubeState, 'B'),
-            left: getFaceStickers(cubeState, 'L'),
-            right: getFaceStickers(cubeState, 'R'),
-            top: getFaceStickers(cubeState, 'U'),
-            bottom: getFaceStickers(cubeState, 'D'),
+            F: getFaceStickers(cubeState, 'F'),
+            B: getFaceStickers(cubeState, 'B'),
+            L: getFaceStickers(cubeState, 'L'),
+            R: getFaceStickers(cubeState, 'R'),
+            U: getFaceStickers(cubeState, 'U'),
+            D: getFaceStickers(cubeState, 'D'),
         }),
         [cubeState],
     );
@@ -378,8 +430,115 @@ const CubeChallenge: React.FC = () => {
 
     const reset = useCallback(() => {
         setCubeState(createInitialCubeState());
-
     }, []);
+
+    const finishFaceDrag = useCallback(
+        (face: FaceKey, target: HTMLDivElement, pointerId: number, commit: boolean) => {
+            const state = faceDragState.current;
+            if (!state || state.pointerId !== pointerId || state.face !== face) {
+                return;
+            }
+
+            if (commit && state.activeMove) {
+                handleMove(state.activeMove);
+            }
+
+            faceDragState.current = null;
+            setActiveFaceDrag(null);
+
+            if (target.hasPointerCapture(pointerId)) {
+                target.releasePointerCapture(pointerId);
+            }
+        },
+        [handleMove],
+    );
+
+    const handleFacePointerDown = useCallback((face: FaceKey, event: React.PointerEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        event.stopPropagation();
+        faceDragState.current = {
+            face,
+            pointerId: event.pointerId,
+            originX: event.clientX,
+            originY: event.clientY,
+            activeMove: null,
+        };
+        setActiveFaceDrag({ face, intent: null });
+        event.currentTarget.setPointerCapture(event.pointerId);
+    }, []);
+
+    const handleFacePointerMove = useCallback(
+        (face: FaceKey, event: React.PointerEvent<HTMLDivElement>) => {
+            const state = faceDragState.current;
+            if (!state || state.pointerId !== event.pointerId || state.face !== face) {
+                return;
+            }
+
+            const deltaX = event.clientX - state.originX;
+            const deltaY = event.clientY - state.originY;
+
+            const absX = Math.abs(deltaX);
+            const absY = Math.abs(deltaY);
+            let intent: DragIntent = null;
+
+            if (absX >= MOVE_DRAG_THRESHOLD || absY >= MOVE_DRAG_THRESHOLD) {
+                if (absX > absY) {
+                    intent = deltaX > 0 ? 'cw' : 'ccw';
+                } else {
+                    intent = 'double';
+                }
+            }
+
+            let nextMove: Move | null = null;
+            if (intent === 'cw') {
+                nextMove = FACE_MOVES[face][0];
+            } else if (intent === 'ccw') {
+                nextMove = FACE_MOVES[face][1];
+            } else if (intent === 'double') {
+                nextMove = FACE_MOVES[face][2];
+            }
+
+            state.activeMove = nextMove;
+            setActiveFaceDrag((prev) => {
+                if (prev && prev.face === face && prev.intent === intent) {
+                    return prev;
+                }
+                return { face, intent };
+            });
+        },
+        [],
+    );
+
+    const handleFacePointerUp = useCallback(
+        (face: FaceKey, event: React.PointerEvent<HTMLDivElement>) => {
+            event.stopPropagation();
+            finishFaceDrag(face, event.currentTarget, event.pointerId, true);
+        },
+        [finishFaceDrag],
+    );
+
+    const handleFacePointerCancel = useCallback(
+        (face: FaceKey, event: React.PointerEvent<HTMLDivElement>) => {
+            finishFaceDrag(face, event.currentTarget, event.pointerId, false);
+        },
+        [finishFaceDrag],
+    );
+
+    const handleFaceKeyDown = useCallback(
+        (face: FaceKey, event: React.KeyboardEvent<HTMLDivElement>) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                handleMove(FACE_MOVES[face][0]);
+            } else if (event.key === 'ArrowLeft') {
+                event.preventDefault();
+                handleMove(FACE_MOVES[face][1]);
+            } else if (event.key === 'ArrowDown') {
+                event.preventDefault();
+                handleMove(FACE_MOVES[face][2]);
+            }
+        },
+        [handleMove],
+    );
 
     return (
         <section className="cube-game">
@@ -387,10 +546,8 @@ const CubeChallenge: React.FC = () => {
                 <h3 className="cube-game__title">Cube Challenge</h3>
 
                 <p className="cube-game__subtitle">
-                    Solve a full 3×3 cube with authentic face turns. Drag to inspect and use the notation buttons to manipulate each
-                    layer.
+                    Spin the cube to inspect every side and drag directly on any face to twist it. Restore every color to solve the puzzle.
                 </p>
-
             </header>
 
             <div
@@ -398,67 +555,64 @@ const CubeChallenge: React.FC = () => {
                 role="application"
                 aria-label="Interactive 3D cube"
                 tabIndex={0}
-                onPointerDown={handlePointerDown}
-                onPointerMove={handlePointerMove}
-                onPointerUp={handlePointerUp}
-                onPointerCancel={handlePointerUp}
+                onPointerDown={handleStagePointerDown}
+                onPointerMove={handleStagePointerMove}
+                onPointerUp={handleStagePointerUp}
+                onPointerCancel={handleStagePointerUp}
                 onKeyDown={handleKeyDown}
             >
+                <div className="cube-game__stage-actions">
+                    <button
+                        type="button"
+                        className="cube-game__stage-button"
+                        onClick={reset}
+                        onPointerDown={(event) => event.stopPropagation()}
+                    >
+                        Reset
+                    </button>
+                    <button
+                        type="button"
+                        className="cube-game__stage-button cube-game__stage-button--primary"
+                        onClick={scramble}
+                        onPointerDown={(event) => event.stopPropagation()}
+                    >
+                        Scramble
+                    </button>
+                </div>
                 <div className="cube-game__scene">
                     <div className="cube-game__cube" style={rotationStyle}>
+                        {FACE_RENDER_CONFIG.map(({ face, className, label }) => {
+                            const isActive = activeFaceDrag?.face === face;
+                            const intent = isActive ? activeFaceDrag?.intent ?? null : null;
+                            const faceClassName = [
+                                className,
+                                'cube-game__face--interactive',
+                                isActive ? 'cube-game__face--dragging' : null,
+                                intent ? `cube-game__face--intent-${intent}` : null,
+                            ]
+                                .filter((value): value is string => Boolean(value))
+                                .join(' ');
 
-                        <CubeFace className="cube-game__face cube-game__face--front" colors={faceColors.front} label="Front" />
-                        <CubeFace className="cube-game__face cube-game__face--back" colors={faceColors.back} label="Back" />
-                        <CubeFace className="cube-game__face cube-game__face--left" colors={faceColors.left} label="Left" />
-                        <CubeFace className="cube-game__face cube-game__face--right" colors={faceColors.right} label="Right" />
-                        <CubeFace className="cube-game__face cube-game__face--top" colors={faceColors.top} label="Top" />
-                        <CubeFace className="cube-game__face cube-game__face--bottom" colors={faceColors.bottom} label="Bottom" />
-
+                            return (
+                                <CubeFace
+                                    key={face}
+                                    face={face}
+                                    className={faceClassName}
+                                    colors={faceColors[face]}
+                                    label={label}
+                                    onPointerDown={handleFacePointerDown}
+                                    onPointerMove={handleFacePointerMove}
+                                    onPointerUp={handleFacePointerUp}
+                                    onPointerCancel={handleFacePointerCancel}
+                                    onKeyDown={handleFaceKeyDown}
+                                />
+                            );
+                        })}
                     </div>
                 </div>
             </div>
-
-            <footer className="cube-game__footer">
-                <div className="cube-game__controls">
-                    <div className="cube-game__move-groups">
-                        {MOVE_GROUPS.map((group) => (
-                            <div key={group.face} className="cube-game__move-group">
-                                <span className="cube-game__move-title">{group.face} face</span>
-                                <div className="cube-game__move-buttons">
-                                    {group.moves.map((move) => (
-                                        <button
-                                            key={move}
-                                            type="button"
-                                            className="cube-game__move-button"
-                                            onClick={() => handleMove(move)}
-                                            aria-label={`Apply ${move} move`}
-                                        >
-                                            {formatMoveLabel(move)}
-                                        </button>
-                                    ))}
-                                </div>
-                            </div>
-                        ))}
-                    </div>
-
-                    <div className="cube-game__buttons">
-                        <button type="button" className="cube-game__button" onClick={reset}>
-                            Reset
-                        </button>
-                        <button type="button" className="cube-game__button cube-game__button--primary" onClick={scramble}>
-                            Scramble
-                        </button>
-                    </div>
-                </div>
-                <p className="cube-game__help">
-                    Use the notation buttons to rotate faces (U = Up, D = Down, etc.). Drag or use the arrow keys to inspect the cube.
-                    <kbd>Home</kbd> resets the view and <kbd>End</kbd> randomizes it.
-                </p>
-            </footer>
         </section>
     );
 };
-
-
 
 export default CubeChallenge;


### PR DESCRIPTION
## Summary
- remove the Cube Challenge control panel and perform turns by dragging directly on cube faces
- add pointer and keyboard handlers with intent highlighting so each face drag fires one twist
- refresh the scene styling with floating reset/scramble actions and drag intent visuals

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68ceb697f9d48326ba6793bfbb0b7f3c