### PR TITLE
Add cube face animations and scene auto rotation

### DIFF
--- a/src/components/games/CubeChallenge.css
+++ b/src/components/games/CubeChallenge.css
@@ -116,6 +116,44 @@
     transition: transform 0.12s ease-out;
 }
 
+.cube-game__face-shell {
+    position: absolute;
+    inset: 0;
+    transform-style: preserve-3d;
+    --face-rotation: 0deg;
+    --face-rotation-duration: 0ms;
+    transition: transform var(--face-rotation-duration) cubic-bezier(0.22, 0.61, 0.36, 1);
+    will-change: transform;
+}
+
+.cube-game__face-shell--animating {
+    pointer-events: none;
+}
+
+.cube-game__face-shell--front {
+    transform: rotateZ(var(--face-rotation)) translateZ(calc(var(--cube-size) / 2));
+}
+
+.cube-game__face-shell--back {
+    transform: rotateZ(var(--face-rotation)) rotateY(180deg) translateZ(calc(var(--cube-size) / 2));
+}
+
+.cube-game__face-shell--left {
+    transform: rotateX(var(--face-rotation)) rotateY(-90deg) translateZ(calc(var(--cube-size) / 2));
+}
+
+.cube-game__face-shell--right {
+    transform: rotateX(var(--face-rotation)) rotateY(90deg) translateZ(calc(var(--cube-size) / 2));
+}
+
+.cube-game__face-shell--top {
+    transform: rotateY(var(--face-rotation)) rotateX(90deg) translateZ(calc(var(--cube-size) / 2));
+}
+
+.cube-game__face-shell--bottom {
+    transform: rotateY(var(--face-rotation)) rotateX(-90deg) translateZ(calc(var(--cube-size) / 2));
+}
+
 .cube-game__face {
     position: absolute;
     inset: 0;
@@ -129,14 +167,14 @@
     border-radius: 18px;
     box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.35);
     touch-action: none;
+    transition: box-shadow 0.2s ease;
 }
 
-.cube-game__face--front { transform: translateZ(calc(var(--cube-size) / 2)); }
-.cube-game__face--back { transform: rotateY(180deg) translateZ(calc(var(--cube-size) / 2)); }
-.cube-game__face--left { transform: rotateY(-90deg) translateZ(calc(var(--cube-size) / 2)); }
-.cube-game__face--right { transform: rotateY(90deg) translateZ(calc(var(--cube-size) / 2)); }
-.cube-game__face--top { transform: rotateX(90deg) translateZ(calc(var(--cube-size) / 2)); }
-.cube-game__face--bottom { transform: rotateX(-90deg) translateZ(calc(var(--cube-size) / 2)); }
+.cube-game__face--animating::after {
+    opacity: 0.8;
+    background: radial-gradient(circle at 50% 50%, rgba(15, 98, 254, 0.35), rgba(15, 98, 254, 0));
+    box-shadow: inset 0 0 30px rgba(15, 98, 254, 0.45);
+}
 
 .cube-game__sticker {
     border-radius: 8px;
@@ -359,13 +397,6 @@
 .cube-game__face--intent-double .cube-game__sticker {
     box-shadow: inset 0 0 6px rgba(92, 57, 165, 0.55), 0 6px 12px rgba(161, 109, 255, 0.28);
 }
-
-.cube-game__face--front { transform: translateZ(calc(var(--cube-size) / 2)); }
-.cube-game__face--back { transform: rotateY(180deg) translateZ(calc(var(--cube-size) / 2)); }
-.cube-game__face--left { transform: rotateY(-90deg) translateZ(calc(var(--cube-size) / 2)); }
-.cube-game__face--right { transform: rotateY(90deg) translateZ(calc(var(--cube-size) / 2)); }
-.cube-game__face--top { transform: rotateX(90deg) translateZ(calc(var(--cube-size) / 2)); }
-.cube-game__face--bottom { transform: rotateX(-90deg) translateZ(calc(var(--cube-size) / 2)); }
 
 .cube-game__sticker {
     border-radius: 8px;

--- a/src/components/games/CubeChallenge.tsx
+++ b/src/components/games/CubeChallenge.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import './CubeChallenge.css';
 
 type Coordinate = -1 | 0 | 1;
@@ -119,6 +119,15 @@ const FACE_CONFIGS: Record<FaceKey, FaceConfig> = {
     },
 };
 
+const FACE_RENDER_CONFIG: Array<{ face: FaceKey; shellClassName: string; label: string }> = [
+    { face: 'F', shellClassName: 'cube-game__face-shell--front', label: 'Front' },
+    { face: 'B', shellClassName: 'cube-game__face-shell--back', label: 'Back' },
+    { face: 'L', shellClassName: 'cube-game__face-shell--left', label: 'Left' },
+    { face: 'R', shellClassName: 'cube-game__face-shell--right', label: 'Right' },
+    { face: 'U', shellClassName: 'cube-game__face-shell--top', label: 'Top' },
+    { face: 'D', shellClassName: 'cube-game__face-shell--bottom', label: 'Bottom' },
+];
+
 interface MoveSpec {
     axis: Axis;
     layer: Coordinate;
@@ -142,6 +151,14 @@ const MOVE_GROUPS: Array<{ face: BaseMove; moves: [Move, Move, Move] }> = [
     { face: 'R', moves: ['R', "R'", 'R2'] },
     { face: 'L', moves: ['L', "L'", 'L2'] },
 ];
+
+const FACE_MOVES: Record<BaseMove, [Move, Move, Move]> = MOVE_GROUPS.reduce(
+    (movesByFace, group) => {
+        movesByFace[group.face] = group.moves;
+        return movesByFace;
+    },
+    {} as Record<BaseMove, [Move, Move, Move]>,
+);
 
 const normalizeCoordinate = (value: number): Coordinate => {
     if (value > 0) {
@@ -210,6 +227,8 @@ const applySingleMove = (stickers: CubeSticker[], move: Move): CubeSticker[] => 
 
 const applyMoves = (stickers: CubeSticker[], moves: Move[]): CubeSticker[] =>
     moves.reduce<CubeSticker[]>((current, move) => applySingleMove(current, move), stickers);
+
+const clamp = (value: number, min: number, max: number): number => Math.min(Math.max(value, min), max);
 
 const generateScramble = (length: number): Move[] => {
     const scramble: Move[] = [];
@@ -331,6 +350,17 @@ interface DraggableMoveControlProps {
     moves: [Move, Move, Move];
     onMove: (move: Move) => void;
 }
+
+const formatMoveLabel = (move: Move): string => {
+    const face = move[0] as BaseMove;
+    if (move.includes('2')) {
+        return `${face} double turn`;
+    }
+    if (move.includes("'")) {
+        return `${face} counter-clockwise`;
+    }
+    return `${face} clockwise`;
+};
 
 const DraggableMoveControl: React.FC<DraggableMoveControlProps> = ({ face, moves, onMove }) => {
     const [clockwise, counterClockwise, doubleTurn] = moves;
@@ -516,9 +546,40 @@ const DraggableMoveControl: React.FC<DraggableMoveControlProps> = ({ face, moves
 const CubeChallenge: React.FC = () => {
     const [rotation, setRotation] = useState<Rotation>(() => ({ x: -30, y: 35 }));
     const [cubeState, setCubeState] = useState<CubeSticker[]>(() => createInitialCubeState());
+    const [autoRotateEnabled, setAutoRotateEnabled] = useState(true);
+    const autoRotateFrameRef = useRef<number | null>(null);
     const stageDragOrigin = useRef<{ x: number; y: number } | null>(null);
+    const [isStageDragging, setIsStageDragging] = useState(false);
     const faceDragState = useRef<(PointerDragState & { face: FaceKey }) | null>(null);
     const [activeFaceDrag, setActiveFaceDrag] = useState<{ face: FaceKey; intent: DragIntent } | null>(null);
+    const [moveQueue, setMoveQueue] = useState<Move[]>([]);
+    const [activeAnimation, setActiveAnimation] = useState<{
+        face: FaceKey;
+        angle: number;
+        duration: number;
+        move: Move;
+    } | null>(null);
+
+    useEffect(() => {
+        if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+            return;
+        }
+
+        const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+        if (mediaQuery.matches) {
+            setAutoRotateEnabled(false);
+        }
+
+        const handleChange = (event: MediaQueryListEvent) => {
+            if (event.matches) {
+                setAutoRotateEnabled(false);
+            }
+        };
+
+        mediaQuery.addEventListener('change', handleChange);
+        return () => mediaQuery.removeEventListener('change', handleChange);
+    }, []);
 
     const handleStagePointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
         if ((event.target as HTMLElement).closest('[data-face]')) {
@@ -527,6 +588,7 @@ const CubeChallenge: React.FC = () => {
 
         stageDragOrigin.current = { x: event.clientX, y: event.clientY };
         event.currentTarget.setPointerCapture(event.pointerId);
+        setIsStageDragging(true);
     }, []);
 
     const handleStagePointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
@@ -546,6 +608,7 @@ const CubeChallenge: React.FC = () => {
 
     const handleStagePointerUp = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
         stageDragOrigin.current = null;
+        setIsStageDragging(false);
         if (event.currentTarget.hasPointerCapture(event.pointerId)) {
             event.currentTarget.releasePointerCapture(event.pointerId);
         }
@@ -579,6 +642,47 @@ const CubeChallenge: React.FC = () => {
         });
     }, []);
 
+    useEffect(() => {
+        if (!autoRotateEnabled || isStageDragging) {
+            if (autoRotateFrameRef.current !== null) {
+                cancelAnimationFrame(autoRotateFrameRef.current);
+                autoRotateFrameRef.current = null;
+            }
+            return () => {};
+        }
+
+        let lastTimestamp: number | null = null;
+
+        const tick = (timestamp: number) => {
+            if (lastTimestamp !== null) {
+                const delta = timestamp - lastTimestamp;
+                setRotation((prev) => {
+                    const nextX = clamp(prev.x + delta * 0.003, -70, 70);
+                    const nextY = prev.y + delta * 0.02;
+                    return { x: nextX, y: nextY };
+                });
+            }
+            lastTimestamp = timestamp;
+            autoRotateFrameRef.current = requestAnimationFrame(tick);
+        };
+
+        autoRotateFrameRef.current = requestAnimationFrame(tick);
+
+        return () => {
+            if (autoRotateFrameRef.current !== null) {
+                cancelAnimationFrame(autoRotateFrameRef.current);
+                autoRotateFrameRef.current = null;
+            }
+        };
+    }, [autoRotateEnabled, isStageDragging]);
+
+    useEffect(() => () => {
+        if (autoRotateFrameRef.current !== null) {
+            cancelAnimationFrame(autoRotateFrameRef.current);
+            autoRotateFrameRef.current = null;
+        }
+    }, []);
+
     const rotationStyle = useMemo(
         () => ({
             transform: `translate3d(-50%, -50%, 0) rotateX(${rotation.x}deg) rotateY(${rotation.y}deg)`,
@@ -599,17 +703,55 @@ const CubeChallenge: React.FC = () => {
     );
 
     const handleMove = useCallback((move: Move) => {
-        setCubeState((prev) => applyMoves(prev, [move]));
+        setMoveQueue((prev) => [...prev, move]);
     }, []);
 
     const scramble = useCallback(() => {
         const sequence = generateScramble(SCRAMBLE_LENGTH);
-        setCubeState((prev) => applyMoves(prev, sequence));
+        setMoveQueue((prev) => [...prev, ...sequence]);
     }, []);
 
     const reset = useCallback(() => {
         setCubeState(createInitialCubeState());
+        setMoveQueue([]);
+        setActiveAnimation(null);
     }, []);
+
+    useEffect(() => {
+        if (activeAnimation || moveQueue.length === 0) {
+            return;
+        }
+
+        const nextMove = moveQueue[0];
+        const base = nextMove[0] as BaseMove;
+        const spec = MOVE_SPECS[base];
+        const isPrime = nextMove.includes("'");
+        const isDouble = nextMove.includes('2');
+        const direction = isPrime ? invertDirection(spec.clockwiseDirection) : spec.clockwiseDirection;
+        const angle = direction * (isDouble ? 180 : 90);
+        const duration = isDouble ? 620 : 420;
+
+        setActiveAnimation({
+            face: base,
+            angle,
+            duration,
+            move: nextMove,
+        });
+    }, [activeAnimation, moveQueue]);
+
+    useEffect(() => {
+        if (!activeAnimation) {
+            return;
+        }
+
+        const timer = window.setTimeout(() => {
+            setCubeState((prev) => applyMoves(prev, [activeAnimation.move]));
+            setMoveQueue((prev) => prev.slice(1));
+            setActiveAnimation(null);
+        }, activeAnimation.duration);
+
+        return () => window.clearTimeout(timer);
+    }, [activeAnimation]);
 
     const finishFaceDrag = useCallback(
         (face: FaceKey, target: HTMLDivElement, pointerId: number, commit: boolean) => {
@@ -744,6 +886,15 @@ const CubeChallenge: React.FC = () => {
                     <button
                         type="button"
                         className="cube-game__stage-button"
+                        onClick={() => setAutoRotateEnabled((prev) => !prev)}
+                        onPointerDown={(event) => event.stopPropagation()}
+                        aria-pressed={autoRotateEnabled}
+                    >
+                        {autoRotateEnabled ? 'Pause rotation' : 'Resume rotation'}
+                    </button>
+                    <button
+                        type="button"
+                        className="cube-game__stage-button"
                         onClick={reset}
                         onPointerDown={(event) => event.stopPropagation()}
                     >
@@ -760,31 +911,49 @@ const CubeChallenge: React.FC = () => {
                 </div>
                 <div className="cube-game__scene">
                     <div className="cube-game__cube" style={rotationStyle}>
-                        {FACE_RENDER_CONFIG.map(({ face, className, label }) => {
+                        {FACE_RENDER_CONFIG.map(({ face, shellClassName, label }) => {
                             const isActive = activeFaceDrag?.face === face;
                             const intent = isActive ? activeFaceDrag?.intent ?? null : null;
                             const faceClassName = [
-                                className,
+                                'cube-game__face',
                                 'cube-game__face--interactive',
                                 isActive ? 'cube-game__face--dragging' : null,
                                 intent ? `cube-game__face--intent-${intent}` : null,
+                                activeAnimation?.face === face ? 'cube-game__face--animating' : null,
                             ]
                                 .filter((value): value is string => Boolean(value))
                                 .join(' ');
 
+                            const wrapperClassName = [
+                                shellClassName,
+                                'cube-game__face-shell',
+                                activeAnimation?.face === face ? 'cube-game__face-shell--animating' : null,
+                            ]
+                                .filter((value): value is string => Boolean(value))
+                                .join(' ');
+
+                            const animationStyle =
+                                activeAnimation?.face === face
+                                    ? ({
+                                          '--face-rotation': `${activeAnimation.angle}deg`,
+                                          '--face-rotation-duration': `${activeAnimation.duration}ms`,
+                                      } as React.CSSProperties)
+                                    : undefined;
+
                             return (
-                                <CubeFace
-                                    key={face}
-                                    face={face}
-                                    className={faceClassName}
-                                    colors={faceColors[face]}
-                                    label={label}
-                                    onPointerDown={handleFacePointerDown}
-                                    onPointerMove={handleFacePointerMove}
-                                    onPointerUp={handleFacePointerUp}
-                                    onPointerCancel={handleFacePointerCancel}
-                                    onKeyDown={handleFaceKeyDown}
-                                />
+                                <div key={face} className={wrapperClassName} style={animationStyle}>
+                                    <CubeFace
+                                        face={face}
+                                        className={faceClassName}
+                                        colors={faceColors[face]}
+                                        label={label}
+                                        onPointerDown={handleFacePointerDown}
+                                        onPointerMove={handleFacePointerMove}
+                                        onPointerUp={handleFacePointerUp}
+                                        onPointerCancel={handleFacePointerCancel}
+                                        onKeyDown={handleFaceKeyDown}
+                                    />
+                                </div>
                             );
                         })}
                     </div>


### PR DESCRIPTION
## Summary
- define the face rendering configuration so the cube component can render each side without throwing
- add helper utilities for move labels and per-face move lookup used by the draggable controls
- animate cube face turns with queued transitions and highlight effects so each move is visually communicated
- add a toggleable auto-rotating scene with reduced-motion awareness for inspecting the cube hands-free

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f409517208328990f5e1fd669684e)